### PR TITLE
Improvements for HTML5/XHTML specifications.

### DIFF
--- a/tda/build/classes/com/pironet/tda/doc/welcome.html
+++ b/tda/build/classes/com/pironet/tda/doc/welcome.html
@@ -1,44 +1,44 @@
 <html>
   <head>
     <title></title>
-    <meta content="">
+    <meta content=""/>
     <style></style>
   </head>
   <body bgcolor="#ffffff">
   <table width="100%" border="0" cellpadding="0" cellspacing="0">
-     <tr><td colspan="2" border=0 bgcolor="#2c2b27"><img src="./logo.png" border=0></td></tr>
+     <tr><td colspan="2" border=0 bgcolor="#2c2b27"><img src="./logo.png" border=0/></td></tr>
      <tr><td colspan="2" align="right"><font size=-1><i>Copyright 2006-2010 - Ingo Rockel <a href="mailto:irockel@dev.java.net">&lt;irockel@dev.java.net&gt;</a></i></font></td></tr>
      <tr><td> </td></tr>
      <tr><td width="40%">
          <center>
              <table bgcolor="#969494" border=0 width="80%"cellspacing="0" cellpadding="3">
              <tr><td width="15px"></td>
-                 <td><img valign="center" src="./important.png"></td><td><br><p><font size="+1"><b>Tip of the day</b></p><hr noshade="true"></font><p>
-                     <!-- ##tipofday## --> </p><br>
+                 <td><img valign="center" src="./important.png"/></td><td><br/><p><font size="+1"><b>Tip of the day</b></p><hr noshade="true"/></font><p>
+                     <!-- ##tipofday## --> </p><br/>
                  </td>
                  <td width="15px"></td>
              </tr>
              </table>
          </center>
      </td><td><table border=0 width=50% cellspacing="0" cellpadding="3">
-     <tr><td bgcolor="#2c2b27" width="15px"></td><td bgcolor="#2c2b27"><img src="./fileopen.png" border="0"></td><td valign="bottom" bgcolor="#2c2b27"><font color="#969494" size=+2><b> Actions </b></td></tr>
-     <tr><td width="10px" colspan="2"></td><td><a href="openlogfile://">Open Logfile...</a><br>
+     <tr><td bgcolor="#2c2b27" width="15px"></td><td bgcolor="#2c2b27"><img src="./fileopen.png" border="0"/></td><td valign="bottom" bgcolor="#2c2b27"><font color="#969494" size=+2><b> Actions </b></td></tr>
+     <tr><td width="10px" colspan="2"></td><td><a href="openlogfile://">Open Logfile...</a><br/>
              <table width="100%">
                  <!-- ##recentlogfiles## -->
              </table>
      </td></tr>
-     <tr><td width="10px" colspan="2"></td><td><a href="opensession://">Open Session...</a><br>
+     <tr><td width="10px" colspan="2"></td><td><a href="opensession://">Open Session...</a><br/>
              <table width="100%">
                  <!-- ##recentsessions## -->
              </table>
      </td></tr>
      <tr></tr>
-     <tr><td bgcolor="#2c2b27" width="15px"></td><td bgcolor="#2c2b27"><img src="./settings.png" border="0"></td><td bgcolor="#2c2b27"><font color="#969494" size=+2><b> Configuration </b></td></tr>
+     <tr><td bgcolor="#2c2b27" width="15px"></td><td bgcolor="#2c2b27"><img src="./settings.png" border="0"/></td><td bgcolor="#2c2b27"><font color="#969494" size=+2><b> Configuration </b></td></tr>
      <tr><td width="10px" colspan="2"></td><td><a href="preferences://">Preferences</a></td></tr>
      <tr><td width="10px" colspan="2"></td><td><a href="filters://">Filters</a></td></tr>
      <tr><td width="10px" colspan="2"></td><td><a href="categories://">Categories</a></td></tr>
      <tr></tr>
-     <tr><td bgcolor="#2c2b27" width="15px"></td><td bgcolor="#2c2b27"><img src="./help.png" border="0"></td><td bgcolor="#2c2b27"><font color="#969494" size=+2><b> Help </b></td></tr>
+     <tr><td bgcolor="#2c2b27" width="15px"></td><td bgcolor="#2c2b27"><img src="./help.png" border="0"/></td><td bgcolor="#2c2b27"><font color="#969494" size=+2><b> Help </b></td></tr>
      <tr><td width="10px" colspan="2"></td><td><a href="overview://">Contents</a></td></tr>
      <tr><td width="10px" colspan="2"></td><td><a href="https://tda.dev.java.net/servlets/ForumMessageList?forumID=1967">Forum</a></td></tr>
      <tr><td width="10px" colspan="2"></td><td><a href="https://tda.dev.java.net/servlets/ForumMessageList?forumID=1967">Mailing Lists</a></td></tr>

--- a/tda/src/java/com/pironet/tda/doc/welcome.html
+++ b/tda/src/java/com/pironet/tda/doc/welcome.html
@@ -1,44 +1,44 @@
 <html>
   <head>
     <title></title>
-    <meta content="">
+    <meta content=""/>
     <style></style>
   </head>
   <body bgcolor="#ffffff">
   <table width="100%" border="0" cellpadding="0" cellspacing="0">
-     <tr><td colspan="2" border=0 bgcolor="#2c2b27"><img src="./logo.png" border=0></td></tr>
+     <tr><td colspan="2" border=0 bgcolor="#2c2b27"><img src="./logo.png" border=0/></td></tr>
      <tr><td colspan="2" align="right"><font size=-1><i>Copyright 2006-2010 - Ingo Rockel <a href="mailto:irockel@dev.java.net">&lt;irockel@dev.java.net&gt;</a></i></font></td></tr>
      <tr><td> </td></tr>
      <tr><td width="40%">
          <center>
              <table bgcolor="#969494" border=0 width="80%"cellspacing="0" cellpadding="3">
              <tr><td width="15px"></td>
-                 <td><img valign="center" src="./important.png"></td><td><br><p><font size="+1"><b>Tip of the day</b></p><hr noshade="true"></font><p>
-                     <!-- ##tipofday## --> </p><br>
+                 <td><img valign="center" src="./important.png"/></td><td><br/><p><font size="+1"><b>Tip of the day</b></p><hr noshade="true"/></font><p>
+                     <!-- ##tipofday## --> </p><br/>
                  </td>
                  <td width="15px"></td>
              </tr>
              </table>
          </center>
      </td><td><table border=0 width=50% cellspacing="0" cellpadding="3">
-     <tr><td bgcolor="#2c2b27" width="15px"></td><td bgcolor="#2c2b27"><img src="./fileopen.png" border="0"></td><td valign="bottom" bgcolor="#2c2b27"><font color="#969494" size=+2><b> Actions </b></td></tr>
-     <tr><td width="10px" colspan="2"></td><td><a href="openlogfile://">Open Logfile...</a><br>
+     <tr><td bgcolor="#2c2b27" width="15px"></td><td bgcolor="#2c2b27"><img src="./fileopen.png" border="0"/></td><td valign="bottom" bgcolor="#2c2b27"><font color="#969494" size=+2><b> Actions </b></td></tr>
+     <tr><td width="10px" colspan="2"></td><td><a href="openlogfile://">Open Logfile...</a><br/>
              <table width="100%">
                  <!-- ##recentlogfiles## -->
              </table>
      </td></tr>
-     <tr><td width="10px" colspan="2"></td><td><a href="opensession://">Open Session...</a><br>
+     <tr><td width="10px" colspan="2"></td><td><a href="opensession://">Open Session...</a><br/>
              <table width="100%">
                  <!-- ##recentsessions## -->
              </table>
      </td></tr>
      <tr></tr>
-     <tr><td bgcolor="#2c2b27" width="15px"></td><td bgcolor="#2c2b27"><img src="./settings.png" border="0"></td><td bgcolor="#2c2b27"><font color="#969494" size=+2><b> Configuration </b></td></tr>
+     <tr><td bgcolor="#2c2b27" width="15px"></td><td bgcolor="#2c2b27"><img src="./settings.png" border="0"/></td><td bgcolor="#2c2b27"><font color="#969494" size=+2><b> Configuration </b></td></tr>
      <tr><td width="10px" colspan="2"></td><td><a href="preferences://">Preferences</a></td></tr>
      <tr><td width="10px" colspan="2"></td><td><a href="filters://">Filters</a></td></tr>
      <tr><td width="10px" colspan="2"></td><td><a href="categories://">Categories</a></td></tr>
      <tr></tr>
-     <tr><td bgcolor="#2c2b27" width="15px"></td><td bgcolor="#2c2b27"><img src="./help.png" border="0"></td><td bgcolor="#2c2b27"><font color="#969494" size=+2><b> Help </b></td></tr>
+     <tr><td bgcolor="#2c2b27" width="15px"></td><td bgcolor="#2c2b27"><img src="./help.png" border="0"/></td><td bgcolor="#2c2b27"><font color="#969494" size=+2><b> Help </b></td></tr>
      <tr><td width="10px" colspan="2"></td><td><a href="overview://">Contents</a></td></tr>
      <tr><td width="10px" colspan="2"></td><td><a href="https://tda.dev.java.net/servlets/ForumMessageList?forumID=1967">Forum</a></td></tr>
      <tr><td width="10px" colspan="2"></td><td><a href="https://tda.dev.java.net/servlets/ForumMessageList?forumID=1967">Mailing Lists</a></td></tr>


### PR DESCRIPTION
**Introduction:**
In accordance with the w3 HTML5 specification for HTML code, void tags (see reference) should be marked as self-closing. During a scan for repositories containing HTML files, we found HTML code in your repository that needed this improvement.

Even though the self-closing specification is not a strict requirement by web-browsers, and they will happily parse the tags anyhow - that is not an excuse for not writing specification valid code. And given the spirit of open-source community, I will be more than happy to push these improvements to you. The changes in this Pull-Request will not break your HTML code, and they have also been manually inspected, to ensure the only change is closing of void elements.

**References:**
https://www.w3.org/TR/html5/syntax.html#void-elements
